### PR TITLE
Feature/remove background location usage

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -80,7 +80,7 @@ android {
 
 dependencies {
 
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlinVersion"
     implementation 'androidx.core:core-ktx:1.6.0'
     implementation 'androidx.appcompat:appcompat:1.3.0'
     implementation 'androidx.fragment:fragment-ktx:1.3.6'

--- a/app/src/main/java/com/johnseymour/solarseasons/Constants.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/Constants.kt
@@ -83,5 +83,6 @@ object Constants
         const val API_KEY = "stored_api_key"
 
         const val CLOUD_COVER_FACTOR_KEY = "cloud_cover_factor"
+        const val LATEST_CITY_NAME_KEY = "latest_city_name"
     }
 }

--- a/app/src/main/java/com/johnseymour/solarseasons/DiskRepository.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/DiskRepository.kt
@@ -8,6 +8,7 @@ import com.johnseymour.solarseasons.api.UVForecastGsonAdapter
 import com.johnseymour.solarseasons.models.SunInfo
 import com.johnseymour.solarseasons.models.UVData
 import com.johnseymour.solarseasons.models.UVForecastData
+import com.johnseymour.solarseasons.models.UVLocationData
 import java.lang.Exception
 import java.time.LocalDate
 import java.time.LocalTime
@@ -67,6 +68,17 @@ object DiskRepository
     fun uvNotificationTimeType(preferences: SharedPreferences): NotificationTimeType
     {
         return NotificationTimeType.from(preferences.getString(Constants.SharedPreferences.UV_PROTECTION_NOTIFICATION_TIME_KEY, null) ?: "") ?: NotificationTimeType.DayStart
+    }
+    fun writeLastCityName(cityName: String, preferences: SharedPreferences)
+    {
+        preferences.edit()
+            .putString(Constants.SharedPreferences.LATEST_CITY_NAME_KEY, cityName)
+            .apply()
+    }
+
+    fun readLastCityName(preferences: SharedPreferences): String?
+    {
+        return preferences.getString(Constants.SharedPreferences.LATEST_CITY_NAME_KEY, null)
     }
 
     enum class NotificationTimeType(val valueString: String)

--- a/app/src/main/java/com/johnseymour/solarseasons/DiskRepository.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/DiskRepository.kt
@@ -69,6 +69,25 @@ object DiskRepository
     {
         return NotificationTimeType.from(preferences.getString(Constants.SharedPreferences.UV_PROTECTION_NOTIFICATION_TIME_KEY, null) ?: "") ?: NotificationTimeType.DayStart
     }
+
+    fun writeLastLocation(location: UVLocationData, preferences: SharedPreferences)
+    {
+        preferences.edit()
+            .putString(Constants.SharedPreferences.MANUAL_LOCATION_LATITUDE_KEY, location.latitude.toString())
+            .putString(Constants.SharedPreferences.MANUAL_LOCATION_LONGITUDE_KEY, location.longitude.toString())
+            .putString(Constants.SharedPreferences.MANUAL_LOCATION_ALTITUDE_KEY, location.altitude.toString())
+            .apply()
+    }
+
+    fun readLastLocation(preferences: SharedPreferences): UVLocationData?
+    {
+        val latitude = preferences.getString(Constants.SharedPreferences.MANUAL_LOCATION_LATITUDE_KEY, null)?.toDoubleOrNull() ?: return null
+        val longitude = preferences.getString(Constants.SharedPreferences.MANUAL_LOCATION_LONGITUDE_KEY, null)?.toDoubleOrNull() ?: return null
+        val altitude = preferences.getString(Constants.SharedPreferences.MANUAL_LOCATION_ALTITUDE_KEY, null)?.toDoubleOrNull() ?: return null
+
+        return UVLocationData(latitude, longitude, altitude)
+    }
+
     fun writeLastCityName(cityName: String, preferences: SharedPreferences)
     {
         preferences.edit()

--- a/app/src/main/java/com/johnseymour/solarseasons/SmallUVDisplay.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/SmallUVDisplay.kt
@@ -1,14 +1,11 @@
 package com.johnseymour.solarseasons
 
-import android.Manifest
 import android.app.PendingIntent
 import android.appwidget.AppWidgetManager
 import android.appwidget.AppWidgetProvider
 import android.content.*
-import android.content.pm.PackageManager
 import android.view.View
 import android.widget.RemoteViews
-import androidx.core.app.ActivityCompat
 import androidx.preference.PreferenceManager
 import com.johnseymour.solarseasons.api.OPENUV_API_KEY
 import com.johnseymour.solarseasons.models.UVData
@@ -54,10 +51,10 @@ class SmallUVDisplay : AppWidgetProvider()
 
         private fun prepareEarliestRequest(context: Context)
         {
-            if (ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_BACKGROUND_LOCATION) == PackageManager.PERMISSION_DENIED)
-            {
-                return
-            }
+//            if (ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_BACKGROUND_LOCATION) == PackageManager.PERMISSION_DENIED)
+//            {
+//                return
+//            }
 
             UVDataWorker.initiateOneTimeWorker(context, firstDailyRequest = isFirstDailyRequest(context), false, Constants.SHORTEST_REFRESH_TIME)
         }
@@ -193,11 +190,11 @@ class SmallUVDisplay : AppWidgetProvider()
             uvData = luvData
             latestError = null
 
-            // Don't initiate a background request if that permission isn't given
-            if (ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_BACKGROUND_LOCATION) != PackageManager.PERMISSION_GRANTED)
-            {
-                return@let
-            }
+//            // Don't initiate a background request if that permission isn't given
+//            if (ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_BACKGROUND_LOCATION) != PackageManager.PERMISSION_GRANTED)
+//            {
+//                return@let
+//            }
 
             if ((usePeriodicWork) && (!luvData.sunInSky()))
             {

--- a/app/src/main/java/com/johnseymour/solarseasons/SmallUVDisplay.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/SmallUVDisplay.kt
@@ -51,11 +51,6 @@ class SmallUVDisplay : AppWidgetProvider()
 
         private fun prepareEarliestRequest(context: Context)
         {
-//            if (ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_BACKGROUND_LOCATION) == PackageManager.PERMISSION_DENIED)
-//            {
-//                return
-//            }
-
             UVDataWorker.initiateOneTimeWorker(context, firstDailyRequest = isFirstDailyRequest(context), false, Constants.SHORTEST_REFRESH_TIME)
         }
 
@@ -190,13 +185,7 @@ class SmallUVDisplay : AppWidgetProvider()
             uvData = luvData
             latestError = null
 
-//            // Don't initiate a background request if that permission isn't given
-//            if (ActivityCompat.checkSelfPermission(context, Manifest.permission.ACCESS_BACKGROUND_LOCATION) != PackageManager.PERMISSION_GRANTED)
-//            {
-//                return@let
-//            }
-
-            if ((usePeriodicWork) && (!luvData.sunInSky()))
+            if ((usePeriodicWork) && (luvData.sunInSky().not()))
             {
                 // Delay the next automatic worker until the sunrise of the next day
                 UVDataWorker.initiatePeriodicWorker(context, timeInterval = backgroundRefreshRate, startDelay = luvData.minutesUntilSunrise)

--- a/app/src/main/java/com/johnseymour/solarseasons/UVDataWorker.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/UVDataWorker.kt
@@ -189,7 +189,9 @@ class UVDataWorker(applicationContext: Context, workerParameters: WorkerParamete
 
                     LocationService.locationDataPromise?.success()
                     {
+                        DiskRepository.writeLastLocation(it, PreferenceManager.getDefaultSharedPreferences(applicationContext))
                         currentUVForLocationData(it, updateCityData = true, result, widgetIntent, activityIntent)
+                        LocationService.locationDataDeferred = null
                     }
                 }
             }

--- a/app/src/main/java/com/johnseymour/solarseasons/UVDataWorker.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/UVDataWorker.kt
@@ -1,10 +1,12 @@
 package com.johnseymour.solarseasons
 
+import android.Manifest
 import android.app.AlarmManager
 import android.app.NotificationManager
 import android.appwidget.AppWidgetManager
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.os.Build
 import androidx.concurrent.futures.CallbackToFutureAdapter
 import androidx.localbroadcastmanager.content.LocalBroadcastManager
@@ -13,8 +15,10 @@ import androidx.work.*
 import com.google.common.util.concurrent.ListenableFuture
 import com.johnseymour.solarseasons.models.UVData
 import com.johnseymour.solarseasons.models.UVForecastData
+import com.johnseymour.solarseasons.models.UVLocationData
 import com.johnseymour.solarseasons.models.UVProtectionTimeData
 import com.johnseymour.solarseasons.services.LocationService
+import com.johnseymour.solarseasons.services.UVDataUseCase
 import nl.komponents.kovenant.deferred
 import java.time.ZonedDateTime
 import java.util.concurrent.TimeUnit
@@ -133,81 +137,166 @@ class UVDataWorker(applicationContext: Context, workerParameters: WorkerParamete
         }
     }
 
+    private var firstDailyRequest: Boolean = false
+
     override fun startWork(): ListenableFuture<Result>
     {
+        firstDailyRequest = inputData.getBoolean(LocationService.FIRST_DAILY_REQUEST_KEY, false)
+
+        val widgetIds = applicationContext.getWidgetIDs()
+
+        val widgetIntent = Intent(applicationContext, SmallUVDisplay::class.java)
+            .setAction(AppWidgetManager.ACTION_APPWIDGET_UPDATE)
+            .putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, widgetIds)
+
+        if (inputData.getBoolean(INITIATE_BACKGROUND_WORK, false))
+        {
+            // For coming from immediate request (no delay), will result in background updates if the relevant permission is granted
+            widgetIntent.putExtra(SmallUVDisplay.START_BACKGROUND_WORK_KEY, true)
+        }
+        else
+        {
+            // The widget is not responsible for starting periodic work except for special situations
+            widgetIntent.putExtra(SmallUVDisplay.START_BACKGROUND_WORK_KEY, !SmallUVDisplay.usePeriodicWork)
+        }
+
+        val activityIntent = Intent(applicationContext, MainActivity::class.java)
+            .setAction(UVData.UV_DATA_UPDATED)
+
         return CallbackToFutureAdapter.getFuture()
         { result ->
-            // Need to initialise this here because the service is created asynchronously
-            LocationService.uvDataDeferred = deferred()
 
-            val locationServiceIntent = LocationService.createServiceIntent(applicationContext)
-            if (inputData.getBoolean(LocationService.FIRST_DAILY_REQUEST_KEY, false))
+            val lastLocationData = DiskRepository.readLastLocation(PreferenceManager.getDefaultSharedPreferences(applicationContext))
+
+            if (lastLocationData == null)
             {
-                locationServiceIntent.putExtra(LocationService.FIRST_DAILY_REQUEST_KEY, true)
-            }
-
-            applicationContext.startForegroundService(locationServiceIntent)
-
-            val widgetIds = applicationContext.getWidgetIDs()
-
-            val widgetIntent = Intent(applicationContext, SmallUVDisplay::class.java)
-                .setAction(AppWidgetManager.ACTION_APPWIDGET_UPDATE)
-                .putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, widgetIds)
-
-            if (inputData.getBoolean(INITIATE_BACKGROUND_WORK, false))
-            {
-                // For coming from immediate request (no delay), will result in background updates if the relevant permission is granted
-                widgetIntent.putExtra(SmallUVDisplay.START_BACKGROUND_WORK_KEY, true)
-            }
-            else
-            {
-                // The widget is not responsible for starting periodic work except for special situations
-                widgetIntent.putExtra(SmallUVDisplay.START_BACKGROUND_WORK_KEY, !SmallUVDisplay.usePeriodicWork)
-            }
-
-            val activityIntent = Intent(applicationContext, MainActivity::class.java)
-                .setAction(UVData.UV_DATA_UPDATED)
-
-            LocationService.uvDataPromise?.success()
-            {
-                val dataSharedPreferences = applicationContext.getSharedPreferences(DiskRepository.DATA_PREFERENCES_NAME, Context.MODE_PRIVATE)
-                DiskRepository.writeLatestUV(it.uvData, dataSharedPreferences)
-
-                it.forecast?.let()
-                { forecastData ->
-                    val updatedForecast = it.protectionTime?.let { protectionData -> setUVForecastProtectionTimeBoundaries(forecastData.toMutableList(), protectionData) } ?: forecastData
-                    DiskRepository.writeLatestForecastList(updatedForecast, dataSharedPreferences)
-                    activityIntent.putParcelableArrayListExtra(UVForecastData.UV_FORECAST_LIST_KEY, ArrayList(updatedForecast))
-                }
-
-                it.protectionTime?.let()
-                { protectionTimeData ->
-                    scheduleProtectionTimeNotification(protectionTimeData)
-                }
-
-                widgetIntent.putExtra(UVData.UV_DATA_KEY, it.uvData)
-                activityIntent.putExtra(UVData.UV_DATA_KEY, it.uvData)
-
-                applicationContext.sendBroadcast(widgetIntent)
-                LocalBroadcastManager.getInstance(applicationContext).sendBroadcast(activityIntent)
-
-                result.set(Result.success())
-            }?.fail()
-            {
-                widgetIntent.putExtra(ErrorStatus.ERROR_STATUS_KEY, it)
-                activityIntent.putExtra(ErrorStatus.ERROR_STATUS_KEY, it)
-
-                if (isFailureError(it))
+                if (applicationContext.checkSelfPermission(Manifest.permission.ACCESS_BACKGROUND_LOCATION) != PackageManager.PERMISSION_GRANTED)
                 {
-                    // Only if not going to retry later show the error message
+                    widgetIntent.putExtra(ErrorStatus.ERROR_STATUS_KEY, ErrorStatus.FineLocationPermissionError)
+                    activityIntent.putExtra(ErrorStatus.ERROR_STATUS_KEY, ErrorStatus.FineLocationPermissionError)
+
                     applicationContext.sendBroadcast(widgetIntent)
                     LocalBroadcastManager.getInstance(applicationContext).sendBroadcast(activityIntent)
                     result.set(Result.failure())
                 }
                 else
                 {
-                    result.set(Result.retry())
+                    LocationService.locationDataDeferred = deferred()
+
+                    val locationServiceIntent = LocationService.createServiceIntent(applicationContext)
+                    applicationContext.startForegroundService(locationServiceIntent)
+
+                    LocationService.locationDataPromise?.success()
+                    {
+                        currentUVForLocationData(it, updateCityData = true, result, widgetIntent, activityIntent)
+                    }
                 }
+            }
+            else
+            {
+                currentUVForLocationData(lastLocationData, updateCityData = false, result, widgetIntent, activityIntent)
+            }
+
+            // Need to initialise this here because the service is created asynchronously
+//            LocationService.uvDataDeferred = deferred()
+//
+//            val locationServiceIntent = LocationService.createServiceIntent(applicationContext)
+//            if (inputData.getBoolean(LocationService.FIRST_DAILY_REQUEST_KEY, false))
+//            {
+//                locationServiceIntent.putExtra(LocationService.FIRST_DAILY_REQUEST_KEY, true)
+//            }
+//
+//            applicationContext.startForegroundService(locationServiceIntent)
+
+
+
+            //UVDataUseCase(applicationContext).getUVData(lastLocationData, firstDailyRequest, updateCityData).success()
+
+//            LocationService.uvDataPromise?.success()
+//            {
+//                val dataSharedPreferences = applicationContext.getSharedPreferences(DiskRepository.DATA_PREFERENCES_NAME, Context.MODE_PRIVATE)
+//                DiskRepository.writeLatestUV(it.uvData, dataSharedPreferences)
+//
+//                it.forecast?.let()
+//                { forecastData ->
+//                    val updatedForecast = it.protectionTime?.let { protectionData -> setUVForecastProtectionTimeBoundaries(forecastData.toMutableList(), protectionData) } ?: forecastData
+//                    DiskRepository.writeLatestForecastList(updatedForecast, dataSharedPreferences)
+//                    activityIntent.putParcelableArrayListExtra(UVForecastData.UV_FORECAST_LIST_KEY, ArrayList(updatedForecast))
+//                }
+//
+//                it.protectionTime?.let()
+//                { protectionTimeData ->
+//                    scheduleProtectionTimeNotification(protectionTimeData)
+//                }
+//
+//                widgetIntent.putExtra(UVData.UV_DATA_KEY, it.uvData)
+//                activityIntent.putExtra(UVData.UV_DATA_KEY, it.uvData)
+//
+//                applicationContext.sendBroadcast(widgetIntent)
+//                LocalBroadcastManager.getInstance(applicationContext).sendBroadcast(activityIntent)
+//
+//                result.set(Result.success())
+//            }?.fail()
+//            {
+//                widgetIntent.putExtra(ErrorStatus.ERROR_STATUS_KEY, it)
+//                activityIntent.putExtra(ErrorStatus.ERROR_STATUS_KEY, it)
+//
+//                if (isFailureError(it))
+//                {
+//                    // Only if not going to retry later show the error message
+//                    applicationContext.sendBroadcast(widgetIntent)
+//                    LocalBroadcastManager.getInstance(applicationContext).sendBroadcast(activityIntent)
+//                    result.set(Result.failure())
+//                }
+//                else
+//                {
+//                    result.set(Result.retry())
+//                }
+//            }
+        }
+    }
+
+    private fun currentUVForLocationData(locationData: UVLocationData, updateCityData: Boolean, workResult: CallbackToFutureAdapter.Completer<Result>, widgetIntent: Intent, activityIntent: Intent)
+    {
+        UVDataUseCase(applicationContext).getUVData(locationData, firstDailyRequest, updateCityData).success()
+        {
+            val dataSharedPreferences = applicationContext.getSharedPreferences(DiskRepository.DATA_PREFERENCES_NAME, Context.MODE_PRIVATE)
+            DiskRepository.writeLatestUV(it.uvData, dataSharedPreferences)
+
+            it.forecast?.let()
+            { forecastData ->
+                val updatedForecast = it.protectionTime?.let { protectionData -> setUVForecastProtectionTimeBoundaries(forecastData.toMutableList(), protectionData) } ?: forecastData
+                DiskRepository.writeLatestForecastList(updatedForecast, dataSharedPreferences)
+                activityIntent.putParcelableArrayListExtra(UVForecastData.UV_FORECAST_LIST_KEY, ArrayList(updatedForecast))
+            }
+
+            it.protectionTime?.let()
+            { protectionTimeData ->
+                scheduleProtectionTimeNotification(protectionTimeData)
+            }
+
+            widgetIntent.putExtra(UVData.UV_DATA_KEY, it.uvData)
+            activityIntent.putExtra(UVData.UV_DATA_KEY, it.uvData)
+
+            applicationContext.sendBroadcast(widgetIntent)
+            LocalBroadcastManager.getInstance(applicationContext).sendBroadcast(activityIntent)
+
+            workResult.set(Result.success())
+        }.fail()
+        {
+            widgetIntent.putExtra(ErrorStatus.ERROR_STATUS_KEY, it)
+            activityIntent.putExtra(ErrorStatus.ERROR_STATUS_KEY, it)
+
+            if (isFailureError(it))
+            {
+                // Only if not going to retry later show the error message
+                applicationContext.sendBroadcast(widgetIntent)
+                LocalBroadcastManager.getInstance(applicationContext).sendBroadcast(activityIntent)
+                workResult.set(Result.failure())
+            }
+            else
+            {
+                workResult.set(Result.retry())
             }
         }
     }

--- a/app/src/main/java/com/johnseymour/solarseasons/UVDataWorker.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/UVDataWorker.kt
@@ -181,6 +181,7 @@ class UVDataWorker(applicationContext: Context, workerParameters: WorkerParamete
                 }
                 else
                 {
+                    // Need to initialise this here because the service is created asynchronously
                     LocationService.locationDataDeferred = deferred()
 
                     val locationServiceIntent = LocationService.createServiceIntent(applicationContext)
@@ -196,63 +197,6 @@ class UVDataWorker(applicationContext: Context, workerParameters: WorkerParamete
             {
                 currentUVForLocationData(lastLocationData, updateCityData = false, result, widgetIntent, activityIntent)
             }
-
-            // Need to initialise this here because the service is created asynchronously
-//            LocationService.uvDataDeferred = deferred()
-//
-//            val locationServiceIntent = LocationService.createServiceIntent(applicationContext)
-//            if (inputData.getBoolean(LocationService.FIRST_DAILY_REQUEST_KEY, false))
-//            {
-//                locationServiceIntent.putExtra(LocationService.FIRST_DAILY_REQUEST_KEY, true)
-//            }
-//
-//            applicationContext.startForegroundService(locationServiceIntent)
-
-
-
-            //UVDataUseCase(applicationContext).getUVData(lastLocationData, firstDailyRequest, updateCityData).success()
-
-//            LocationService.uvDataPromise?.success()
-//            {
-//                val dataSharedPreferences = applicationContext.getSharedPreferences(DiskRepository.DATA_PREFERENCES_NAME, Context.MODE_PRIVATE)
-//                DiskRepository.writeLatestUV(it.uvData, dataSharedPreferences)
-//
-//                it.forecast?.let()
-//                { forecastData ->
-//                    val updatedForecast = it.protectionTime?.let { protectionData -> setUVForecastProtectionTimeBoundaries(forecastData.toMutableList(), protectionData) } ?: forecastData
-//                    DiskRepository.writeLatestForecastList(updatedForecast, dataSharedPreferences)
-//                    activityIntent.putParcelableArrayListExtra(UVForecastData.UV_FORECAST_LIST_KEY, ArrayList(updatedForecast))
-//                }
-//
-//                it.protectionTime?.let()
-//                { protectionTimeData ->
-//                    scheduleProtectionTimeNotification(protectionTimeData)
-//                }
-//
-//                widgetIntent.putExtra(UVData.UV_DATA_KEY, it.uvData)
-//                activityIntent.putExtra(UVData.UV_DATA_KEY, it.uvData)
-//
-//                applicationContext.sendBroadcast(widgetIntent)
-//                LocalBroadcastManager.getInstance(applicationContext).sendBroadcast(activityIntent)
-//
-//                result.set(Result.success())
-//            }?.fail()
-//            {
-//                widgetIntent.putExtra(ErrorStatus.ERROR_STATUS_KEY, it)
-//                activityIntent.putExtra(ErrorStatus.ERROR_STATUS_KEY, it)
-//
-//                if (isFailureError(it))
-//                {
-//                    // Only if not going to retry later show the error message
-//                    applicationContext.sendBroadcast(widgetIntent)
-//                    LocalBroadcastManager.getInstance(applicationContext).sendBroadcast(activityIntent)
-//                    result.set(Result.failure())
-//                }
-//                else
-//                {
-//                    result.set(Result.retry())
-//                }
-//            }
         }
     }
 

--- a/app/src/main/java/com/johnseymour/solarseasons/api/NetworkRepository.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/api/NetworkRepository.kt
@@ -153,6 +153,12 @@ object NetworkRepository
     {
         val result = deferred<UVData, ErrorStatus>()
 
+        if (Constants.TEST_MODE_NO_API)
+        {
+            result.resolve(UVData.generateTestData())
+            return result.promise
+        }
+
         openUVAPI.getRealTimeUV(latitude, longitude, validateAltitude(altitude)).enqueue(object: Callback<UVData>
         {
             override fun onResponse(call: Call<UVData>, response: Response<UVData>)

--- a/app/src/main/java/com/johnseymour/solarseasons/current_uv_screen/CurrentUVFragment.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/current_uv_screen/CurrentUVFragment.kt
@@ -297,7 +297,7 @@ class CurrentUVFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener
             viewModel.readForecastFromDisk(dataSharedPreferences)
             viewModel.readUVFromDisk(dataSharedPreferences)
 
-        } catch (e: FileNotFoundException){ }
+        } catch (_: FileNotFoundException){ }
     }
 
     override fun onRefresh()
@@ -466,7 +466,7 @@ class CurrentUVFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener
                         lForecastList.add(0, currentData)
                     }
 
-                    forecastBestScrollPosition++
+                    forecastBestScrollPosition = 0
                 }
 
                 in 0 until it.size-1 -> // Replace the nearest time with the current lUVData.uv

--- a/app/src/main/java/com/johnseymour/solarseasons/current_uv_screen/CurrentUVFragment.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/current_uv_screen/CurrentUVFragment.kt
@@ -25,17 +25,12 @@ import androidx.preference.PreferenceManager
 import androidx.recyclerview.widget.GridLayoutManager
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
-import androidx.work.ListenableWorker.Result
 import com.johnseymour.solarseasons.*
-import com.johnseymour.solarseasons.UVDataWorker.Companion.INITIATE_BACKGROUND_WORK
 import com.johnseymour.solarseasons.current_uv_screen.uv_forecast.UVForecastAdapter
 import com.johnseymour.solarseasons.models.*
-import com.johnseymour.solarseasons.services.LocationService
-import com.johnseymour.solarseasons.services.UVDataUseCase
 import com.johnseymour.solarseasons.settings_screen.PreferenceScreenFragment
 import com.johnseymour.solarseasons.settings_screen.SettingsFragment
 import kotlinx.android.synthetic.main.fragment_current_uv.*
-import nl.komponents.kovenant.deferred
 import java.io.FileNotFoundException
 import java.time.ZonedDateTime
 
@@ -264,8 +259,9 @@ class CurrentUVFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener
 
             if ((viewModel.uvData?.minutesSinceDataRetrieved ?: 0) > Constants.MINIMUM_APP_FOREGROUND_REFRESH_TIME)
             {
-                onRefresh() // Manually simulate swiping down to start a new request
+                // Manually simulate swiping down to start a new request
                 layout.isRefreshing = true
+                viewModel.updateCurrentUV(requireContext(), false)
             }
         }
 
@@ -310,83 +306,13 @@ class CurrentUVFragment : Fragment(), SwipeRefreshLayout.OnRefreshListener
         {
             appStatusInformation.visibility = View.INVISIBLE
             launchAppDetailsButton.visibility = View.INVISIBLE
-            UVDataWorker.initiateOneTimeWorker(requireContext(), viewModel.isForecastNotCurrent())
-        }
-        else if (layout.isRefreshing)
-        {
-            layout.isRefreshing = false
-        }
-    }
-
-    private fun getCurrentUVData()
-    {
-        // Need to initialise this here because the service is created asynchronously
-   //     LocationService.uvDataDeferred = deferred()
-
-        val locationServiceIntent = LocationService.createServiceIntent(requireContext())
-        if (inputData.getBoolean(LocationService.FIRST_DAILY_REQUEST_KEY, false))
-        {
-            locationServiceIntent.putExtra(LocationService.FIRST_DAILY_REQUEST_KEY, true)
-        }
-
-        applicationContext.startForegroundService(locationServiceIntent)
-
-        val widgetIds = applicationContext.getWidgetIDs()
-
-        val widgetIntent = Intent(applicationContext, SmallUVDisplay::class.java)
-            .setAction(AppWidgetManager.ACTION_APPWIDGET_UPDATE)
-            .putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, widgetIds)
-
-        if (inputData.getBoolean(INITIATE_BACKGROUND_WORK, false))
-        {
-            // For coming from immediate request (no delay), will result in background updates if the relevant permission is granted
-            widgetIntent.putExtra(SmallUVDisplay.START_BACKGROUND_WORK_KEY, true)
+            viewModel.updateCurrentUV(requireContext(), true)
         }
         else
         {
-            // The widget is not responsible for starting periodic work except for special situations
-            widgetIntent.putExtra(SmallUVDisplay.START_BACKGROUND_WORK_KEY, !SmallUVDisplay.usePeriodicWork)
-        }
-
-        val activityIntent = Intent(requireContext(), MainActivity::class.java)
-            .setAction(UVData.UV_DATA_UPDATED)
-
-        UVDataUseCase(requireContext()).getUVData(UVDataUseCase.UVLocationData(1,1,1), false, viewModel.isForecastNotCurrent(), false).success()
-        {
-            val context = context ?: return@success
-
-            val dataSharedPreferences = context.getSharedPreferences(DiskRepository.DATA_PREFERENCES_NAME, Context.MODE_PRIVATE)
-            DiskRepository.writeLatestUV(it.uvData, dataSharedPreferences)
-
-            it.forecast?.let()
-            { forecastData ->
-                DiskRepository.writeLatestForecastList(forecastData, dataSharedPreferences)
-                activityIntent.putParcelableArrayListExtra(UVForecastData.UV_FORECAST_LIST_KEY, ArrayList(forecastData))
-            }
-
-            widgetIntent.putExtra(UVData.UV_DATA_KEY, it.uvData)
-            activityIntent.putExtra(UVData.UV_DATA_KEY, it.uvData)
-
-            context.sendBroadcast(widgetIntent)
-            LocalBroadcastManager.getInstance(context).sendBroadcast(activityIntent)
-        }
-
-        LocationService.uvDataPromise?.success()
-        {
-
-
-            result.set(Result.success())
-        }?.fail()
-        {
-            widgetIntent.putExtra(ErrorStatus.ERROR_STATUS_KEY, it)
-            activityIntent.putExtra(ErrorStatus.ERROR_STATUS_KEY, it)
-
-            if (isFailureError(it))
-            {
-                // Only if not going to retry later show the error message
-                context?.sendBroadcast(widgetIntent)
-                LocalBroadcastManager.getInstance(applicationContext).sendBroadcast(activityIntent)
-            }
+            appStatusInformation.visibility = View.INVISIBLE
+            launchAppDetailsButton.visibility = View.INVISIBLE
+            viewModel.updateCurrentUV(requireContext(), false)
         }
     }
 

--- a/app/src/main/java/com/johnseymour/solarseasons/current_uv_screen/MainViewModel.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/current_uv_screen/MainViewModel.kt
@@ -148,7 +148,6 @@ class MainViewModel: ViewModel()
         }
     }
 
-    // TODO call from fragment, for pull down swipe refresh can force location update, otherwise for autocall dont
     fun updateCurrentUV(context: Context, forceLocationUpdate: Boolean = false)
     {
         val lastLocationData = DiskRepository.readLastLocation(PreferenceManager.getDefaultSharedPreferences(context))

--- a/app/src/main/java/com/johnseymour/solarseasons/current_uv_screen/MainViewModel.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/current_uv_screen/MainViewModel.kt
@@ -41,6 +41,7 @@ class MainViewModel: ViewModel()
                 {
                     intent.getParcelableExtra<UVLocationData>(UVLocationData.UV_LOCATION_KEY)?.let()
                     {
+                        DiskRepository.writeLastLocation(it, PreferenceManager.getDefaultSharedPreferences(context))
                         // Always update city data for a new location
                         currentUVForLocationData(context, it, true)
                     }

--- a/app/src/main/java/com/johnseymour/solarseasons/current_uv_screen/MainViewModel.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/current_uv_screen/MainViewModel.kt
@@ -147,6 +147,7 @@ class MainViewModel: ViewModel()
         }
     }
 
+    // TODO call from fragment, for pull down swipe refresh can force location update, otherwise for autocall dont
     fun updateCurrentUV(context: Context, forceLocationUpdate: Boolean = false)
     {
         val lastLocationData = DiskRepository.readLastLocation(PreferenceManager.getDefaultSharedPreferences(context))

--- a/app/src/main/java/com/johnseymour/solarseasons/current_uv_screen/MainViewModel.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/current_uv_screen/MainViewModel.kt
@@ -1,15 +1,23 @@
 package com.johnseymour.solarseasons.current_uv_screen
 
+import android.appwidget.AppWidgetManager
 import android.content.*
 import android.text.format.DateFormat
 import android.util.DisplayMetrics
 import androidx.lifecycle.ViewModel
+import androidx.localbroadcastmanager.content.LocalBroadcastManager
+import androidx.preference.PreferenceManager
 import com.johnseymour.solarseasons.DiskRepository
 import com.johnseymour.solarseasons.ErrorStatus
+import com.johnseymour.solarseasons.MainActivity
 import com.johnseymour.solarseasons.R
+import com.johnseymour.solarseasons.SmallUVDisplay
+import com.johnseymour.solarseasons.getWidgetIDs
 import com.johnseymour.solarseasons.isNotEqual
 import com.johnseymour.solarseasons.models.UVData
 import com.johnseymour.solarseasons.models.UVForecastData
+import com.johnseymour.solarseasons.models.UVLocationData
+import com.johnseymour.solarseasons.services.UVDataUseCase
 import java.time.LocalDate
 
 class MainViewModel: ViewModel()
@@ -110,6 +118,57 @@ class MainViewModel: ViewModel()
         uvData?.let()
         {
             DiskRepository.writeLatestUV(it, context.getSharedPreferences(DiskRepository.DATA_PREFERENCES_NAME, Context.MODE_PRIVATE))
+        }
+    }
+
+    fun updateCurrentUV(context: Context, forceLocationUpdate: Boolean = false)
+    {
+        val lastLocationData = DiskRepository.readLastLocation(PreferenceManager.getDefaultSharedPreferences(context))
+
+        if (lastLocationData == null || forceLocationUpdate)
+        {
+            // TODO launch location service with broadcast back to this VM
+            return
+        }
+
+        currentUVForLocationData(context, lastLocationData, false)
+    }
+
+    private fun currentUVForLocationData(context: Context, locationData: UVLocationData, updateCityData: Boolean)
+    {
+        val widgetIds = context.getWidgetIDs()
+
+        val widgetIntent = Intent(context, SmallUVDisplay::class.java)
+            .setAction(AppWidgetManager.ACTION_APPWIDGET_UPDATE)
+            .putExtra(AppWidgetManager.EXTRA_APPWIDGET_IDS, widgetIds)
+            .putExtra(SmallUVDisplay.START_BACKGROUND_WORK_KEY, true)
+
+        val activityIntent = Intent(context, MainActivity::class.java)
+            .setAction(UVData.UV_DATA_UPDATED)
+
+        UVDataUseCase(context).getUVData(locationData, isForecastNotCurrent(), updateCityData).success()
+        {
+            val dataSharedPreferences = context.getSharedPreferences(DiskRepository.DATA_PREFERENCES_NAME, Context.MODE_PRIVATE)
+            DiskRepository.writeLatestUV(it.uvData, dataSharedPreferences)
+
+            it.forecast?.let()
+            { forecastData ->
+                DiskRepository.writeLatestForecastList(forecastData, dataSharedPreferences)
+                activityIntent.putParcelableArrayListExtra(UVForecastData.UV_FORECAST_LIST_KEY, ArrayList(forecastData))
+            }
+
+            widgetIntent.putExtra(UVData.UV_DATA_KEY, it.uvData)
+            activityIntent.putExtra(UVData.UV_DATA_KEY, it.uvData)
+
+            context.sendBroadcast(widgetIntent)
+            LocalBroadcastManager.getInstance(context).sendBroadcast(activityIntent)
+        }.fail()
+        {
+            widgetIntent.putExtra(ErrorStatus.ERROR_STATUS_KEY, it)
+            activityIntent.putExtra(ErrorStatus.ERROR_STATUS_KEY, it)
+
+            context.sendBroadcast(widgetIntent)
+            LocalBroadcastManager.getInstance(context).sendBroadcast(activityIntent)
         }
     }
 }

--- a/app/src/main/java/com/johnseymour/solarseasons/models/UVData.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/models/UVData.kt
@@ -265,5 +265,35 @@ data class UVData(
                 R.color.uv_extreme_alternate
             }
         }
+
+        private var counter = 0F
+
+        fun generateTestData(): UVData
+        {
+            counter++
+            return UVData(
+                uv = counter, uvTime = ZonedDateTime.parse("2021-09-25T00:00:30.826+10:00[Australia/Sydney]"),
+                uvMax = 3.0005F, uvMaxTime = ZonedDateTime.parse("2021-09-25T21:53:36.274+10:00[Australia/Sydney]"),
+                ozone = 332.5F, ozoneTime = ZonedDateTime.parse("2021-09-25T16:04:07.137+10:00[Australia/Sydney]"),
+                safeExposure = mapOf("st1" to 4180, "st2" to 5016, "st3" to 6688, "st4" to 8360, "st5" to 13376, "st6" to 25079),
+                sunInfo = SunInfo(
+                    solarNoon = ZonedDateTime.parse("2021-09-25T21:53:36.274+10:00[Australia/Sydney]"),
+                    nadir = ZonedDateTime.parse("2021-09-25T09:53:36.274+10:00[Australia/Sydney]"),
+                    sunrise = ZonedDateTime.parse("2021-09-25T15:52:48.317+10:00[Australia/Sydney]"),
+                    sunset = ZonedDateTime.parse("2021-09-26T03:54:24.230+10:00[Australia/Sydney]"),
+                    sunriseEnd = ZonedDateTime.parse("2021-09-25T15:56:13.870+10:00[Australia/Sydney]"),
+                    sunsetStart = ZonedDateTime.parse("2021-09-26T03:50:58.677+10:00[Australia/Sydney]"),
+                    dawn = ZonedDateTime.parse("2021-09-25T15:19:32.279+10:00[Australia/Sydney]"),
+                    dusk = ZonedDateTime.parse("2021-09-26T04:27:40.269+10:00[Australia/Sydney]"),
+                    nauticalDawn = ZonedDateTime.parse("2021-09-25T14:40:20.870+10:00[Australia/Sydney]"),
+                    nauticalDusk = ZonedDateTime.parse("2021-09-26T05:06:51.678+10:00[Australia/Sydney]"),
+                    nightEnd = ZonedDateTime.parse("2021-09-25T13:59:43.486+10:00[Australia/Sydney]"),
+                    night = ZonedDateTime.parse("2021-09-26T05:47:29.061+10:00[Australia/Sydney]"),
+                    goldenHourEnd = ZonedDateTime.parse("2021-09-25T16:36:54.771+10:00[Australia/Sydney]"),
+                    goldenHour = ZonedDateTime.parse("2021-09-26T03:10:17.776+10:00[Australia/Sydney]"),
+                    azimuth = -1.48815118586359, altitude = 0.04749226792696052
+                )
+            )
+        }
     }
 }

--- a/app/src/main/java/com/johnseymour/solarseasons/models/UVLocationData.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/models/UVLocationData.kt
@@ -1,0 +1,3 @@
+package com.johnseymour.solarseasons.models
+
+data class UVLocationData(val latitude: Double, val longitude: Double, val altitude: Double)

--- a/app/src/main/java/com/johnseymour/solarseasons/models/UVLocationData.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/models/UVLocationData.kt
@@ -11,15 +11,4 @@ data class UVLocationData(val latitude: Double, val longitude: Double, val altit
     {
         const val UV_LOCATION_KEY = "uv_location_key"
     }
-
-    override fun describeContents(): Int
-    {
-        //TODO("Not yet implemented")
-        return 0
-    }
-
-    override fun writeToParcel(p0: Parcel?, p1: Int)
-    {
-        //TODO("Not yet implemented")
-    }
 }

--- a/app/src/main/java/com/johnseymour/solarseasons/models/UVLocationData.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/models/UVLocationData.kt
@@ -1,3 +1,25 @@
 package com.johnseymour.solarseasons.models
 
-data class UVLocationData(val latitude: Double, val longitude: Double, val altitude: Double)
+import android.os.Parcel
+import android.os.Parcelable
+import kotlinx.android.parcel.Parcelize
+
+@Parcelize
+data class UVLocationData(val latitude: Double, val longitude: Double, val altitude: Double): Parcelable
+{
+    companion object
+    {
+        const val UV_LOCATION_KEY = "uv_location_key"
+    }
+
+    override fun describeContents(): Int
+    {
+        //TODO("Not yet implemented")
+        return 0
+    }
+
+    override fun writeToParcel(p0: Parcel?, p1: Int)
+    {
+        //TODO("Not yet implemented")
+    }
+}

--- a/app/src/main/java/com/johnseymour/solarseasons/services/LocationService.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/services/LocationService.kt
@@ -9,10 +9,8 @@ import android.content.Intent
 import android.content.pm.ServiceInfo
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
-import androidx.localbroadcastmanager.content.LocalBroadcastManager
 import com.johnseymour.solarseasons.*
 import com.johnseymour.solarseasons.api.NetworkRepository
-import com.johnseymour.solarseasons.models.UVCombinedForecastData
 import com.johnseymour.solarseasons.models.UVData
 import com.johnseymour.solarseasons.models.UVForecastData
 import com.johnseymour.solarseasons.models.UVLocationData
@@ -37,13 +35,6 @@ abstract class LocationService: Service()
         private const val NOTIFICATION_CHANNEL_NAME = "Solar.seasons.foreground_location_channel"
 
         const val FIRST_DAILY_REQUEST_KEY = "first_daily_request_key"
-
-        var uvDataDeferred: Deferred<UVCombinedForecastData, ErrorStatus>? = null
-        val uvDataPromise: Promise<UVCombinedForecastData, ErrorStatus>?
-            get()
-            {
-                return uvDataDeferred?.promise
-            }
 
         var locationDataDeferred: Deferred<UVLocationData, ErrorStatus>? = null
         val locationDataPromise: Promise<UVLocationData, ErrorStatus>?
@@ -137,17 +128,17 @@ abstract class LocationService: Service()
         return result
     }
 
-    private fun networkRequestsComplete()
-    {
-        uvData?.let()
-        {
-            it.cloudCover = cloudCover
-            it.cityName = cityName
-            uvDataDeferred?.resolve(UVCombinedForecastData(it, uvForecast, uvProtection))
-        }
-
-        stopSelf()
-    }
+//    private fun networkRequestsComplete()
+//    {
+//        uvData?.let()
+//        {
+//            it.cloudCover = cloudCover
+//            it.cityName = cityName
+//            locationDataDeferred?.resolve(UVCombinedForecastData(it, uvForecast, uvProtection))
+//        }
+//
+//        stopSelf()
+//    }
 
     private var requestsMade = AtomicInteger(0)
     private var canRetryRequest = true // Single retry of realtime UV data allowed
@@ -241,7 +232,7 @@ abstract class LocationService: Service()
 
             if (requestsMade.incrementAndGet() == networkRequestsToMake)
             {
-                networkRequestsComplete()
+             //   networkRequestsComplete()
             }
         }.fail()
         { errorStatus ->
@@ -252,7 +243,7 @@ abstract class LocationService: Service()
             }
             else
             {
-                uvDataDeferred?.reject(errorStatus)
+                locationDataDeferred?.reject(errorStatus)
                 stopSelf()
             }
         }
@@ -266,7 +257,7 @@ abstract class LocationService: Service()
      */
     fun finalLocationFailure(errorStatus: ErrorStatus)
     {
-        uvDataDeferred?.reject(errorStatus)
+        locationDataDeferred?.reject(errorStatus)
         stopSelf()
     }
 
@@ -274,9 +265,9 @@ abstract class LocationService: Service()
     {
         super.onDestroy()
 
-        if (uvDataDeferred?.promise?.isDone() == false)
+        if (locationDataDeferred?.promise?.isDone() == false)
         {
-            uvDataDeferred?.reject(ErrorStatus.LocationServiceTerminated)
+            locationDataDeferred?.reject(ErrorStatus.LocationServiceTerminated)
         }
     }
 }

--- a/app/src/main/java/com/johnseymour/solarseasons/services/LocationService.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/services/LocationService.kt
@@ -38,8 +38,6 @@ abstract class LocationService: Service()
 
         const val FIRST_DAILY_REQUEST_KEY = "first_daily_request_key"
 
-        const val LOCATION_UPDATE_RECEIVED = "com.johnseymour.solarseasons.LOCATION_UPDATE_RECEIVED"
-
         var uvDataDeferred: Deferred<UVCombinedForecastData, ErrorStatus>? = null
         val uvDataPromise: Promise<UVCombinedForecastData, ErrorStatus>?
             get()
@@ -156,13 +154,7 @@ abstract class LocationService: Service()
 
     fun locationSuccess(latitude: Double, longitude: Double, altitude: Double)
     {
-        val intent = Intent(LOCATION_UPDATE_RECEIVED).apply()
-        {
-            val uvLocationData = UVLocationData(latitude, longitude, altitude)
-            putExtra(UVLocationData.UV_LOCATION_KEY, uvLocationData)
-            locationDataDeferred?.resolve(uvLocationData)
-        }
-        LocalBroadcastManager.getInstance(applicationContext).sendBroadcast(intent)
+        locationDataDeferred?.resolve(UVLocationData(latitude, longitude, altitude))
         stopSelf()
 //        val isCloudCoverEnabled = PreferenceManager.getDefaultSharedPreferences(applicationContext)
 //            .getBoolean(Constants.SharedPreferences.CLOUD_COVER_FACTOR_KEY, false)

--- a/app/src/main/java/com/johnseymour/solarseasons/services/LocationService.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/services/LocationService.kt
@@ -47,6 +47,13 @@ abstract class LocationService: Service()
                 return uvDataDeferred?.promise
             }
 
+        var locationDataDeferred: Deferred<UVLocationData, ErrorStatus>? = null
+        val locationDataPromise: Promise<UVLocationData, ErrorStatus>?
+            get()
+            {
+                return locationDataDeferred?.promise
+            }
+
         /**
          * Factory method that checks application-level settings to determine which implementation of the
          *  LocationService class to use.
@@ -151,7 +158,9 @@ abstract class LocationService: Service()
     {
         val intent = Intent(LOCATION_UPDATE_RECEIVED).apply()
         {
-            putExtra(UVLocationData.UV_LOCATION_KEY, UVLocationData(latitude, longitude, altitude))
+            val uvLocationData = UVLocationData(latitude, longitude, altitude)
+            putExtra(UVLocationData.UV_LOCATION_KEY, uvLocationData)
+            locationDataDeferred?.resolve(uvLocationData)
         }
         LocalBroadcastManager.getInstance(applicationContext).sendBroadcast(intent)
         stopSelf()

--- a/app/src/main/java/com/johnseymour/solarseasons/services/LocationService.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/services/LocationService.kt
@@ -10,15 +10,10 @@ import android.content.pm.ServiceInfo
 import android.os.IBinder
 import androidx.core.app.NotificationCompat
 import com.johnseymour.solarseasons.*
-import com.johnseymour.solarseasons.api.NetworkRepository
-import com.johnseymour.solarseasons.models.UVData
-import com.johnseymour.solarseasons.models.UVForecastData
 import com.johnseymour.solarseasons.models.UVLocationData
-import com.johnseymour.solarseasons.models.UVProtectionTimeData
 import com.johnseymour.solarseasons.settings_screen.PreferenceScreenFragment
 import nl.komponents.kovenant.Deferred
 import nl.komponents.kovenant.Promise
-import java.util.concurrent.atomic.AtomicInteger
 
 /**
  * Abstract class to implement custom location implementations using different location APIs.
@@ -112,141 +107,10 @@ abstract class LocationService: Service()
 
     override fun onBind(intent: Intent): IBinder? = null
 
-    private var uvData: UVData? = null
-    private var cloudCover: Double? = null
-    private var cityName: String? = null
-    private var uvForecast: List<UVForecastData>? = null
-    private var uvProtection: UVProtectionTimeData? = null
-
-    private fun calculateNumberOfRequests(cloudCoverEnabled: Boolean): Int
-    {
-        var result = 2 // City name and UV data always fetched
-
-        if (cloudCoverEnabled) { result++ }
-        if (firstRequestOfDay) { result += 2 }
-
-        return result
-    }
-
-//    private fun networkRequestsComplete()
-//    {
-//        uvData?.let()
-//        {
-//            it.cloudCover = cloudCover
-//            it.cityName = cityName
-//            locationDataDeferred?.resolve(UVCombinedForecastData(it, uvForecast, uvProtection))
-//        }
-//
-//        stopSelf()
-//    }
-
-    private var requestsMade = AtomicInteger(0)
-    private var canRetryRequest = true // Single retry of realtime UV data allowed
-
     fun locationSuccess(latitude: Double, longitude: Double, altitude: Double)
     {
         locationDataDeferred?.resolve(UVLocationData(latitude, longitude, altitude))
         stopSelf()
-//        val isCloudCoverEnabled = PreferenceManager.getDefaultSharedPreferences(applicationContext)
-//            .getBoolean(Constants.SharedPreferences.CLOUD_COVER_FACTOR_KEY, false)
-//
-//        val networkRequestsToMake = calculateNumberOfRequests(isCloudCoverEnabled)
-//
-//        if (isCloudCoverEnabled)
-//        {
-//            NetworkRepository.getCurrentCloudCover(latitude, longitude).success()
-//            { lCloudCover ->
-//                cloudCover = lCloudCover
-//
-//                if (requestsMade.incrementAndGet() == networkRequestsToMake)
-//                {
-//                    networkRequestsComplete()
-//                }
-//            }.fail() // Failure of cloud cover data is non-critical
-//            {
-//                if (requestsMade.incrementAndGet() == networkRequestsToMake)
-//                {
-//                    networkRequestsComplete()
-//                }
-//            }
-//        }
-//
-//        if (firstRequestOfDay)
-//        {
-//            NetworkRepository.getUVForecast(latitude, longitude, altitude).success()
-//            { lUVForecast ->
-//
-//                uvForecast = lUVForecast
-//
-//                if (requestsMade.incrementAndGet() == networkRequestsToMake)
-//                {
-//                    networkRequestsComplete()
-//                }
-//            }.fail() // Failure of forecast data is also non-critical
-//            {
-//                if (requestsMade.incrementAndGet() == networkRequestsToMake)
-//                {
-//                    networkRequestsComplete()
-//                }
-//            }
-//
-//            NetworkRepository.getUVProtectionTimes(latitude, longitude, altitude, Constants.UV_PROTECTION_TIME_DEFAULT_FROM_UV, Constants.UV_PROTECTION_TIME_DEFAULT_TO_UV).success()
-//            { lUVProtection ->
-//                uvProtection = lUVProtection
-//                if (requestsMade.incrementAndGet() == networkRequestsToMake)
-//                {
-//                    networkRequestsComplete()
-//                }
-//            }.fail() // Failure of protection data is also non-critical
-//            {
-//                if (requestsMade.incrementAndGet() == networkRequestsToMake)
-//                {
-//                    networkRequestsComplete()
-//                }
-//            }
-//        }
-//
-//        NetworkRepository.getGeoCodedCityName(latitude, longitude).success()
-//        { lCityName ->
-//            cityName = lCityName
-//            if (requestsMade.incrementAndGet() == networkRequestsToMake)
-//            {
-//                networkRequestsComplete()
-//            }
-//        }.fail() // Failure of city name data is non-critical
-//        {
-//            if (requestsMade.incrementAndGet() == networkRequestsToMake)
-//            {
-//                networkRequestsComplete()
-//            }
-//        }
-//
-//        makeRealTimeUVRequest(latitude, longitude, altitude, networkRequestsToMake)
-    }
-
-    private fun makeRealTimeUVRequest(latitude: Double, longitude: Double, altitude: Double, networkRequestsToMake: Int)
-    {
-        NetworkRepository.getRealTimeUV(latitude, longitude, altitude).success()
-        { luvData ->
-            uvData = luvData
-
-            if (requestsMade.incrementAndGet() == networkRequestsToMake)
-            {
-             //   networkRequestsComplete()
-            }
-        }.fail()
-        { errorStatus ->
-            if ((canRetryRequest) && (errorStatus != ErrorStatus.NetworkError))
-            {
-                canRetryRequest = false
-                makeRealTimeUVRequest(latitude, longitude, altitude, networkRequestsToMake)
-            }
-            else
-            {
-                locationDataDeferred?.reject(errorStatus)
-                stopSelf()
-            }
-        }
     }
 
     /**

--- a/app/src/main/java/com/johnseymour/solarseasons/services/LocationService.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/services/LocationService.kt
@@ -251,9 +251,9 @@ abstract class LocationService: Service()
 
     /**
      * Called when it is determined that the location cannot be determined anymore. Rejects the current
-     *  uvDataDeferred promise and stops this service.
+     *  locationDataDeferred promise and stops this service.
      *
-     *  @param errorStatus - ErrorStatus used to reject the uvDataDeferred promise with.
+     *  @param errorStatus - ErrorStatus used to reject the locationDataDeferred promise with.
      */
     fun finalLocationFailure(errorStatus: ErrorStatus)
     {

--- a/app/src/main/java/com/johnseymour/solarseasons/services/LocationServiceManual.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/services/LocationServiceManual.kt
@@ -16,7 +16,7 @@ class LocationServiceManual: LocationService()
 
         if ((latitude == null) || (longitude == null) || (altitude == null))
         {
-            uvDataDeferred?.reject(ErrorStatus.ManualLocationError)
+            locationDataDeferred?.reject(ErrorStatus.ManualLocationError)
             stopSelf()
             return START_STICKY
         }

--- a/app/src/main/java/com/johnseymour/solarseasons/services/LocationServiceNonGoogle.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/services/LocationServiceNonGoogle.kt
@@ -37,11 +37,11 @@ class LocationServiceNonGoogle: LocationService(), Consumer<Location?>, Location
             // Due to battery saver being on
             if ((getSystemService(Context.POWER_SERVICE) as? PowerManager)?.locationPowerSaveMode != PowerManager.LOCATION_MODE_NO_CHANGE)
             {
-                uvDataDeferred?.reject(ErrorStatus.LocationBatterySaverError)
+                locationDataDeferred?.reject(ErrorStatus.LocationBatterySaverError)
             }
             else
             {
-                uvDataDeferred?.reject(ErrorStatus.LocationDisabledError)
+                locationDataDeferred?.reject(ErrorStatus.LocationDisabledError)
             }
             stopSelf()
 
@@ -63,7 +63,7 @@ class LocationServiceNonGoogle: LocationService(), Consumer<Location?>, Location
         }
         else
         {
-            uvDataDeferred?.reject(ErrorStatus.LocationAnyPermissionError)
+            locationDataDeferred?.reject(ErrorStatus.LocationAnyPermissionError)
             stopSelf()
         }
 

--- a/app/src/main/java/com/johnseymour/solarseasons/services/LocationServiceTestNoAPI.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/services/LocationServiceTestNoAPI.kt
@@ -3,6 +3,7 @@ package com.johnseymour.solarseasons.services
 import com.johnseymour.solarseasons.models.SunInfo
 import com.johnseymour.solarseasons.models.UVCombinedForecastData
 import com.johnseymour.solarseasons.models.UVData
+import com.johnseymour.solarseasons.models.UVLocationData
 import java.time.ZonedDateTime
 
 class LocationServiceTestNoAPI: LocationService()
@@ -42,7 +43,7 @@ class LocationServiceTestNoAPI: LocationService()
     override fun serviceMain(): Int
     {
         counter++
-        uvDataDeferred?.resolve(UVCombinedForecastData(generateTestData(), null, null))
+        locationDataDeferred?.resolve(UVLocationData(-37.9050904, 144.9330945, 10.0))
 
         stopSelf()
 

--- a/app/src/main/java/com/johnseymour/solarseasons/services/LocationServiceTestNoAPI.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/services/LocationServiceTestNoAPI.kt
@@ -1,47 +1,11 @@
 package com.johnseymour.solarseasons.services
 
-import com.johnseymour.solarseasons.models.SunInfo
-import com.johnseymour.solarseasons.models.UVData
 import com.johnseymour.solarseasons.models.UVLocationData
-import java.time.ZonedDateTime
 
 class LocationServiceTestNoAPI: LocationService()
 {
-    companion object
-    {
-        private var counter = 0F
-
-        private fun generateTestData(): UVData
-        {
-            return UVData(
-                uv = counter, uvTime = ZonedDateTime.parse("2021-09-25T00:00:30.826+10:00[Australia/Sydney]"),
-                uvMax = 3.0005F, uvMaxTime = ZonedDateTime.parse("2021-09-25T21:53:36.274+10:00[Australia/Sydney]"),
-                ozone = 332.5F, ozoneTime = ZonedDateTime.parse("2021-09-25T16:04:07.137+10:00[Australia/Sydney]"),
-                safeExposure = mapOf("st1" to 4180, "st2" to 5016, "st3" to 6688, "st4" to 8360, "st5" to 13376, "st6" to 25079),
-                sunInfo = SunInfo(
-                    solarNoon = ZonedDateTime.parse("2021-09-25T21:53:36.274+10:00[Australia/Sydney]"),
-                    nadir = ZonedDateTime.parse("2021-09-25T09:53:36.274+10:00[Australia/Sydney]"),
-                    sunrise = ZonedDateTime.parse("2021-09-25T15:52:48.317+10:00[Australia/Sydney]"),
-                    sunset = ZonedDateTime.parse("2021-09-26T03:54:24.230+10:00[Australia/Sydney]"),
-                    sunriseEnd = ZonedDateTime.parse("2021-09-25T15:56:13.870+10:00[Australia/Sydney]"),
-                    sunsetStart = ZonedDateTime.parse("2021-09-26T03:50:58.677+10:00[Australia/Sydney]"),
-                    dawn = ZonedDateTime.parse("2021-09-25T15:19:32.279+10:00[Australia/Sydney]"),
-                    dusk = ZonedDateTime.parse("2021-09-26T04:27:40.269+10:00[Australia/Sydney]"),
-                    nauticalDawn = ZonedDateTime.parse("2021-09-25T14:40:20.870+10:00[Australia/Sydney]"),
-                    nauticalDusk = ZonedDateTime.parse("2021-09-26T05:06:51.678+10:00[Australia/Sydney]"),
-                    nightEnd = ZonedDateTime.parse("2021-09-25T13:59:43.486+10:00[Australia/Sydney]"),
-                    night = ZonedDateTime.parse("2021-09-26T05:47:29.061+10:00[Australia/Sydney]"),
-                    goldenHourEnd = ZonedDateTime.parse("2021-09-25T16:36:54.771+10:00[Australia/Sydney]"),
-                    goldenHour = ZonedDateTime.parse("2021-09-26T03:10:17.776+10:00[Australia/Sydney]"),
-                    azimuth = -1.48815118586359, altitude = 0.04749226792696052
-                )
-            )
-        }
-    }
-
     override fun serviceMain(): Int
     {
-        counter++
         locationDataDeferred?.resolve(UVLocationData(-37.9050904, 144.9330945, 10.0))
 
         stopSelf()

--- a/app/src/main/java/com/johnseymour/solarseasons/services/LocationServiceTestNoAPI.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/services/LocationServiceTestNoAPI.kt
@@ -1,7 +1,6 @@
 package com.johnseymour.solarseasons.services
 
 import com.johnseymour.solarseasons.models.SunInfo
-import com.johnseymour.solarseasons.models.UVCombinedForecastData
 import com.johnseymour.solarseasons.models.UVData
 import com.johnseymour.solarseasons.models.UVLocationData
 import java.time.ZonedDateTime

--- a/app/src/main/java/com/johnseymour/solarseasons/services/UVDataUseCase.kt
+++ b/app/src/main/java/com/johnseymour/solarseasons/services/UVDataUseCase.kt
@@ -1,0 +1,282 @@
+package com.johnseymour.solarseasons.services
+
+import android.app.AlarmManager
+import android.app.NotificationManager
+import android.content.Context
+import android.os.Build
+import androidx.preference.PreferenceManager
+import com.johnseymour.solarseasons.Constants
+import com.johnseymour.solarseasons.DiskRepository
+import com.johnseymour.solarseasons.ErrorStatus
+import com.johnseymour.solarseasons.api.NetworkRepository
+import com.johnseymour.solarseasons.models.UVCombinedForecastData
+import com.johnseymour.solarseasons.models.UVData
+import com.johnseymour.solarseasons.models.UVForecastData
+import com.johnseymour.solarseasons.models.UVLocationData
+import com.johnseymour.solarseasons.models.UVProtectionTimeData
+import com.johnseymour.solarseasons.toEpochMilli
+import nl.komponents.kovenant.Deferred
+import nl.komponents.kovenant.Promise
+import nl.komponents.kovenant.deferred
+import java.time.ZonedDateTime
+import java.util.concurrent.atomic.AtomicInteger
+import kotlin.math.absoluteValue
+
+class UVDataUseCase(val context: Context)
+{
+    private var canRetryRequest = true // Single retry of realtime UV data allowed
+
+    private var uvData: UVData? = null
+    private var cloudCover: Double? = null
+    private var cityName: String? = null
+    private var uvForecast: List<UVForecastData>? = null
+    private var uvProtection: UVProtectionTimeData? = null
+
+    private fun calculateNumberOfRequests(cloudCoverEnabled: Boolean, isFirstDailyRequest: Boolean, updateCityData: Boolean): Int
+    {
+        var result = 1 // UV data always fetched
+
+        if (updateCityData) { result++ }
+        if (cloudCoverEnabled) { result++ }
+        if (isFirstDailyRequest) { result += 2 } // Protection times and UV forecast
+
+        return result
+    }
+
+    /** Modifies a UVForecastData list to find and set elements whose time is the closest match to the passed UVProtectionTimeData. */
+    private fun getUVForecastWithProtectionTimeBoundaries(): List<UVForecastData>?
+    {
+        val forecastData = uvForecast?.toMutableList() ?: return null
+        val protectionTimeData = uvProtection ?: return forecastData
+
+        if (protectionTimeData.isProtectionNeeded.not()) { return forecastData }
+
+        var fromTimeForecastIndex = 0
+        while ((fromTimeForecastIndex < forecastData.size - 1) && ((forecastData[fromTimeForecastIndex].time).isBefore(protectionTimeData.fromTime)))
+        {
+            fromTimeForecastIndex++
+        }
+        fromTimeForecastIndex = if (fromTimeForecastIndex > 0) fromTimeForecastIndex - 1 else fromTimeForecastIndex
+
+        val fromUvAtIndex = forecastData[fromTimeForecastIndex].uv
+        val fromUvAtNext = forecastData[if (fromTimeForecastIndex < forecastData.size - 1) fromTimeForecastIndex + 1 else fromTimeForecastIndex].uv
+
+        // If the next UV is closer to the protection UV then use that, increase the index
+        if ((fromUvAtIndex - protectionTimeData.fromUV).absoluteValue > (fromUvAtNext - protectionTimeData.fromUV).absoluteValue)
+        {
+            fromTimeForecastIndex++
+        }
+
+        var toTimeForecastIndex = 0
+        while ((toTimeForecastIndex < forecastData.size - 1) && (forecastData[toTimeForecastIndex].time).isBefore(protectionTimeData.toTime))
+        {
+            toTimeForecastIndex++
+        }
+        toTimeForecastIndex = if (toTimeForecastIndex > 0) toTimeForecastIndex - 1 else toTimeForecastIndex
+
+        val toUvAtIndex = forecastData[toTimeForecastIndex].uv
+        val toUvAtNext = forecastData[if (toTimeForecastIndex < forecastData.size - 1) toTimeForecastIndex + 1 else toTimeForecastIndex].uv
+
+        // If the next UV is closer to the protection UV then use that, increase the index
+        if ((toUvAtIndex - protectionTimeData.toUV).absoluteValue > (toUvAtNext - protectionTimeData.toUV).absoluteValue)
+        {
+            toTimeForecastIndex++
+        }
+
+        forecastData[fromTimeForecastIndex] = forecastData[fromTimeForecastIndex].copy(isProtectionTimeBoundary = true)
+        forecastData[toTimeForecastIndex] = forecastData[toTimeForecastIndex].copy(isProtectionTimeBoundary = true)
+
+        return forecastData
+    }
+
+    private fun networkRequestsComplete(deferredResult: Deferred<UVCombinedForecastData, ErrorStatus>)
+    {
+        uvData?.let()
+        {
+            it.cloudCover = cloudCover
+            it.cityName = cityName
+            deferredResult.resolve(UVCombinedForecastData(it, getUVForecastWithProtectionTimeBoundaries(), uvProtection))
+        }
+    }
+
+    fun getUVData(locationData: UVLocationData, withCloudCover: Boolean, isFirstDailyRequest: Boolean, updateCityData: Boolean): Promise<UVCombinedForecastData, ErrorStatus>
+    {
+        val result = deferred<UVCombinedForecastData, ErrorStatus>()
+
+        val networkRequestsToMake = calculateNumberOfRequests(withCloudCover, isFirstDailyRequest, updateCityData)
+        val requestsMade = AtomicInteger(0)
+
+        if (withCloudCover)
+        {
+            NetworkRepository.getCurrentCloudCover(locationData.latitude, locationData.longitude).success()
+            { lCloudCover ->
+                cloudCover = lCloudCover
+
+                if (requestsMade.incrementAndGet() == networkRequestsToMake)
+                {
+                    networkRequestsComplete(result)
+                }
+            }.fail() // Failure of cloud cover data is non-critical
+            {
+                if (requestsMade.incrementAndGet() == networkRequestsToMake)
+                {
+                    networkRequestsComplete(result)
+                }
+            }
+        }
+
+        if (isFirstDailyRequest)
+        {
+            NetworkRepository.getUVForecast(locationData.latitude, locationData.longitude, locationData.altitude).success()
+            { lUVForecast ->
+
+                uvForecast = lUVForecast
+
+                if (requestsMade.incrementAndGet() == networkRequestsToMake)
+                {
+                    networkRequestsComplete(result)
+                }
+            }.fail() // Failure of forecast data is also non-critical
+            {
+                if (requestsMade.incrementAndGet() == networkRequestsToMake)
+                {
+                    networkRequestsComplete(result)
+                }
+            }
+
+            NetworkRepository.getUVProtectionTimes(locationData.latitude, locationData.longitude, locationData.altitude, Constants.UV_PROTECTION_TIME_DEFAULT_FROM_UV, Constants.UV_PROTECTION_TIME_DEFAULT_TO_UV).success()
+            { lUVProtection ->
+                uvProtection = lUVProtection
+                scheduleProtectionTimeNotification(lUVProtection)
+                if (requestsMade.incrementAndGet() == networkRequestsToMake)
+                {
+                    networkRequestsComplete(result)
+                }
+            }.fail() // Failure of protection data is also non-critical
+            {
+                if (requestsMade.incrementAndGet() == networkRequestsToMake)
+                {
+                    networkRequestsComplete(result)
+                }
+            }
+        }
+
+        if (updateCityData)
+        {
+            // Todo, if location has not changed then also dont need to make this call
+            NetworkRepository.getGeoCodedCityName(locationData.latitude, locationData.longitude).success()
+            { lCityName ->
+                cityName = lCityName
+                if (requestsMade.incrementAndGet() == networkRequestsToMake)
+                {
+                    networkRequestsComplete(result)
+                }
+            }.fail() // Failure of city name data is non-critical
+            {
+                if (requestsMade.incrementAndGet() == networkRequestsToMake)
+                {
+                    networkRequestsComplete(result)
+                }
+            }
+        }
+        // TODO() else needs to be handled outside this, use shared preferences to get last city name
+
+        makeRealTimeUVRequest(locationData, networkRequestsToMake, result, requestsMade)
+
+        return result.promise
+    }
+
+    private fun makeRealTimeUVRequest(
+        locationData: UVLocationData,
+        networkRequestsToMake: Int,
+        deferredResult: Deferred<UVCombinedForecastData, ErrorStatus>,
+        requestsMade: AtomicInteger
+    )
+    {
+        NetworkRepository.getRealTimeUV(locationData.latitude, locationData.longitude, locationData.altitude).success()
+        { luvData ->
+            uvData = luvData
+
+            if (requestsMade.incrementAndGet() == networkRequestsToMake)
+            {
+                networkRequestsComplete(deferredResult)
+            }
+        }.fail()
+        { errorStatus ->
+            if ((canRetryRequest) && (errorStatus != ErrorStatus.NetworkError))
+            {
+                canRetryRequest = false
+                makeRealTimeUVRequest(locationData, networkRequestsToMake, deferredResult, requestsMade)
+            }
+            else
+            {
+                deferredResult.reject(errorStatus)
+            }
+        }
+    }
+
+    private fun scheduleProtectionTimeNotification(protectionTimeData: UVProtectionTimeData)
+    {
+        if (protectionTimeData.isProtectionNeeded.not()) { return }
+
+        val notificationManager = context.getSystemService(Context.NOTIFICATION_SERVICE) as NotificationManager
+        if (notificationManager.areNotificationsEnabled().not()) { return }
+
+        val alarmManager = context.getSystemService(Context.ALARM_SERVICE) as AlarmManager
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S && alarmManager.canScheduleExactAlarms().not()) { return }
+
+        val timeNow = ZonedDateTime.now()
+
+        var protectionTimeAlreadyStarted = false
+
+        val defaultPreferences = PreferenceManager.getDefaultSharedPreferences(context)
+
+        if (defaultPreferences.getBoolean(Constants.SharedPreferences.UV_PROTECTION_NOTIFICATION_KEY, true).not()) { return }
+
+        val protectionStartScheduleTime = when (DiskRepository.uvNotificationTimeType(defaultPreferences))
+        {
+            DiskRepository.NotificationTimeType.DayStart ->
+            {
+                if (timeNow.isAfter(protectionTimeData.fromTime))
+                {
+                    protectionTimeAlreadyStarted = true
+                }
+                timeNow
+            }
+
+            DiskRepository.NotificationTimeType.Custom ->
+            {
+                val uvNotificationCustomTime = DiskRepository.uvNotificationCustomTime(defaultPreferences) ?: timeNow
+                if (timeNow.isAfter(uvNotificationCustomTime))
+                {
+                    timeNow
+                }
+                else
+                {
+                    uvNotificationCustomTime
+                }
+            }
+
+            DiskRepository.NotificationTimeType.WhenNeeded ->
+            {
+                protectionTimeAlreadyStarted = true
+                if (timeNow.isAfter(protectionTimeData.fromTime))
+                {
+                    timeNow
+                }
+                else
+                {
+                    protectionTimeData.fromTime
+                }
+            }
+        }
+
+        alarmManager.set(AlarmManager.RTC, protectionStartScheduleTime.toEpochMilli(), protectionTimeData.protectionStartPendingIntent(context, protectionTimeAlreadyStarted))
+
+        val uvEndNotificationsEnabled = defaultPreferences.getBoolean(Constants.SharedPreferences.UV_PROTECTION_END_NOTIFICATION_KEY, true)
+        if (uvEndNotificationsEnabled)
+        {
+            alarmManager.set(AlarmManager.RTC, protectionTimeData.toTime.toEpochMilli(), protectionTimeData.protectionEndPendingIntent(context))
+        }
+    }
+}


### PR DESCRIPTION
- Removed need for background location permission when using widgets, app now saves the last known location to sharedpreferences and references this when updating UV data
- If background permission is given will still work same as before -> all background UV updates will get location first then make API call
- Auto-UV update when launch app also now only uses last known location, if available
- The only time location is always retrieved (assuming any location permission is given) is when the user does a force swipe refresh on the main UV fragment